### PR TITLE
Fix docs, auth, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ A comprehensive web application for analyzing and visualizing workout data from 
 3. Create a `.env` file for configuration:
 
    ```env
-   REACT_APP_API_URL=http://localhost:5000/api
+   REACT_APP_API_URL=http://localhost:8000/api
    ```
 
 4. Start the development server:
@@ -66,7 +66,7 @@ A comprehensive web application for analyzing and visualizing workout data from 
      ```
    - Start the backend server:
      ```bash
-     uvicorn api:app --reload
+     uvicorn api.main:app --reload
      ```
 
 ## Usage

--- a/api/core/auth.py
+++ b/api/core/auth.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 from api.core.config import settings, logger
 from otf_api import Otf
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/login")
 
 async def get_otf_client(credentials):
     """Create and return an OTF client"""

--- a/frontend/src/components/login.test.js
+++ b/frontend/src/components/login.test.js
@@ -14,11 +14,8 @@ test('email validation on submit', () => {
     fireEvent.click(submitButton)
   })
 
-  // Debug: Check what is being rendered
-  console.log(queryByText('Email is required'))
-
   // Expect to see the email error message
-  expect(queryByText('Email is required')).toBeTruthy()
+  expect(queryByText('Email is required')).toBeInTheDocument()
 
   // Enter an invalid email
   act(() => {
@@ -27,7 +24,7 @@ test('email validation on submit', () => {
   })
 
   // Expect to see the invalid email error message
-  expect(queryByText('Please enter a valid email')).toBeTruthy()
+  expect(queryByText('Please enter a valid email')).toBeInTheDocument()
 })
 
 test('password validation on submit', () => {
@@ -44,9 +41,6 @@ test('password validation on submit', () => {
     fireEvent.click(submitButton)
   })
 
-  // Debug: Check what is being rendered
-  console.log(queryByText('Password is required'))
-
   // Expect to see the password error message
-  expect(queryByText('Password is required')).toBeTruthy()
+  expect(queryByText('Password is required')).toBeInTheDocument()
 })


### PR DESCRIPTION
## Summary
- correct backend startup command in README
- update example API port in README
- fix OAuth token URL to `/api/login`
- clean up frontend login tests

## Testing
- `npx --prefix frontend jest` *(fails: connect EHOSTUNREACH 172.25.0.3:8080)*