### PR TITLE
Use API base url env var

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -6,3 +6,12 @@ Currently, two official plugins are available:
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
 - [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+
+## Environment variables
+
+Set `VITE_API_BASE_URL` to configure the backend API base URL used by the
+frontend. This value is read from `import.meta.env` at runtime. For example:
+
+```bash
+VITE_API_BASE_URL=http://localhost:8000/api
+```

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -1,7 +1,9 @@
 // src/utils/api.js
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
+
 export const loginUser = async (data, rememberMe) => {
   try {
-    const response = await fetch('http://localhost:8000/api/login', {
+    const response = await fetch(`${API_BASE_URL}/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data),


### PR DESCRIPTION
## Summary
- reference VITE_API_BASE_URL in login API helper
- document VITE_API_BASE_URL in README

## Testing
- `npm --prefix frontend test` *(fails: jest not found)*